### PR TITLE
move TMDB requests to server

### DIFF
--- a/server/controller.js
+++ b/server/controller.js
@@ -1,4 +1,5 @@
 const { Thing } = require('./models/things');
+const { getTmdbData } = require('./external-apis/tmdb');
 
 const fetchItems = async (request, reply) => {
     const showDeletedQueryValue =
@@ -46,4 +47,14 @@ const deleteItems = async (request, reply) => {
     }
 };
 
-module.exports = { fetchItems, addItem, updateItem, deleteItems };
+const getTmdbDataController = async (request, reply) => {
+    const { searchTerm } = request.query;
+    try {
+        const data = await getTmdbData(searchTerm);
+        reply.send(data);
+    } catch (error) {
+        reply.status(500).send({ error: 'Failed to fetch data from TMDB API' });
+    }
+};
+
+module.exports = { fetchItems, addItem, updateItem, deleteItems, getTmdbDataController };

--- a/server/external-apis/tmdb.js
+++ b/server/external-apis/tmdb.js
@@ -1,9 +1,9 @@
-import axios from 'axios';
+const axios = require('axios');
+const {
+    parsed: { TMDB_BASE_URL, TMDB_TOKEN }
+} = require('dotenv').config({ path: '.env.local' });
 
-const TMDB_BASE_URL = process.env.REACT_APP_TMDB_BASE_URL;
-const TMDB_TOKEN = process.env.REACT_APP_TMDB_TOKEN;
-
-export const getTmdbData = async (searchTerm) => {
+const getTmdbData = async (searchTerm) => {
     const url = `${TMDB_BASE_URL}/search/tv?query=${searchTerm}&include_adult=false&language=en-US&page=1`;
     const options = {
         method: 'GET',
@@ -20,3 +20,5 @@ export const getTmdbData = async (searchTerm) => {
         throw error;
     }
 };
+
+module.exports = { getTmdbData };

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,4 +1,10 @@
-const { fetchItems, addItem, updateItem, deleteItems } = require('./controller');
+const {
+    fetchItems,
+    addItem,
+    updateItem,
+    deleteItems,
+    getTmdbDataController
+} = require('./controller');
 
 const routes = [
     {
@@ -20,6 +26,11 @@ const routes = [
         method: 'DELETE',
         url: '/api/things/:ids',
         handler: deleteItems
+    },
+    {
+        method: 'GET',
+        url: '/api/tmdb/search',
+        handler: getTmdbDataController
     }
 ];
 

--- a/src/api.js
+++ b/src/api.js
@@ -15,3 +15,7 @@ export const updateItemInApi = (item) => {
 export const deleteItemsFromApi = (ids) => {
     return axios.delete(`/api/things/${ids}`);
 };
+
+export const fetchItemsFromTmdb = (searchTerm) => {
+    return axios.get('/api/tmdb/search', { params: { searchTerm } });
+};

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -22,7 +22,7 @@ const Sidebar = () => {
         ) {
             dispatch(getTmdbDataAction(name));
         }
-    }, [isSidebarVisible, externalData, sidebarDataOptions]);
+    }, [isSidebarVisible, sidebarData, sidebarDataOptions]);
 
     const handleHide = () => {
         dispatch(setIsSidebarVisible(false, null));

--- a/src/redux/actions/action-dispatchers.js
+++ b/src/redux/actions/action-dispatchers.js
@@ -4,9 +4,9 @@ import {
     fetchItemsFromApi,
     createItemInApi,
     updateItemInApi,
-    deleteItemsFromApi
+    deleteItemsFromApi,
+    fetchItemsFromTmdb
 } from '../../api';
-import { getTmdbData } from '../../external-apis/tmdb';
 
 import {
     createItemSuccess,
@@ -64,9 +64,8 @@ export const deleteItemsAction = (ids) => {
 export const getTmdbDataAction = (searchTerm) => {
     return (dispatch) => {
         dispatch(getTmdbDataBegin());
-        getTmdbData(searchTerm)
+        fetchItemsFromTmdb(searchTerm)
             .then((data) => {
-                console.log('bb ~  ~ file: actions.js:118 ~ .then ~ data:', data);
                 dispatch(getTmdbDataSuccess(data));
             })
             .catch((error) => dispatch(getTmdbDataFailure(error)));

--- a/src/redux/reducers/reducer.js
+++ b/src/redux/reducers/reducer.js
@@ -120,7 +120,7 @@ export default function (state = initialState, action) {
                 ...state,
                 loading: false,
                 errors: null,
-                sidebarDataOptions: action.payload.data.results
+                sidebarDataOptions: action.payload.data.data.results
             };
         case GET_TMDB_DATA_FAILURE:
             return {


### PR DESCRIPTION
Moved TMDB api calls to server-side:
- move tmdb dir to server
- add to controller.js
- add to routes.js
- add to api.js
- update action dispatcher
- update reducer

Benefits of 3rd party api calls on server-side:
- More secure -- can use .env.local instead of exposing secrets.
- Cleaner code, easier maintenance.